### PR TITLE
leaf rc

### DIFF
--- a/Sources/Mustache/MustacheParser.swift
+++ b/Sources/Mustache/MustacheParser.swift
@@ -59,13 +59,13 @@ extension TemplateByteScanner {
 
         let open = try [requirePop(), requirePop()] // {{
         guard open == [.leftCurlyBracket, .leftCurlyBracket] else {
-            throw TemplateError.parse(reason: "Invalid tag open", source: makeSource(using: start))
+            throw TemplateError.parse(reason: "Invalid tag open", template: makeSource(using: start), source: .capture())
         }
 
         let type: TemplateSyntaxType
 
         guard let key = peek() else {
-            throw TemplateError.parse(reason: "Unexpected EOF", source: makeSource(using: start))
+            throw TemplateError.parse(reason: "Unexpected EOF", template: makeSource(using: start), source: .capture())
         }
 
         switch key {
@@ -81,7 +81,7 @@ extension TemplateByteScanner {
             // pop tag close
             let close = try [requirePop(), requirePop(), requirePop()] // }}}
             guard close == [.rightCurlyBracket, .rightCurlyBracket, .rightCurlyBracket] else {
-                throw TemplateError.parse(reason: "Invalid tag close", source: makeSource(using: start))
+                throw TemplateError.parse(reason: "Invalid tag close", template: makeSource(using: start), source: .capture())
             }
 
             let tag = TemplateTag(name: "get", parameters: [id], body: nil)
@@ -98,7 +98,7 @@ extension TemplateByteScanner {
             // pop tag close
             let close = try [requirePop(), requirePop()] // }}
             guard close == [.rightCurlyBracket, .rightCurlyBracket] else {
-                throw TemplateError.parse(reason: "Invalid tag close", source: makeSource(using: start))
+                throw TemplateError.parse(reason: "Invalid tag close", template: makeSource(using: start), source: .capture())
             }
 
             // parse section body
@@ -133,7 +133,7 @@ extension TemplateByteScanner {
             // pop tag close
             let close = try [requirePop(), requirePop()] // }}
             guard close == [.rightCurlyBracket, .rightCurlyBracket] else {
-                throw TemplateError.parse(reason: "Invalid tag close", source: makeSource(using: start))
+                throw TemplateError.parse(reason: "Invalid tag close", template: makeSource(using: start), source: .capture())
             }
 
             let tag = TemplateTag(name: "_end", parameters: [id], body: nil)
@@ -147,7 +147,7 @@ extension TemplateByteScanner {
             // pop tag close
             let close = try [requirePop(), requirePop()] // }}
             guard close == [.rightCurlyBracket, .rightCurlyBracket] else {
-                throw TemplateError.parse(reason: "Invalid tag close", source: makeSource(using: start))
+                throw TemplateError.parse(reason: "Invalid tag close", template: makeSource(using: start), source: .capture())
             }
 
             let tag = TemplateTag(name: "", parameters: [id], body: nil)

--- a/Sources/TemplateKit/TemplateError.swift
+++ b/Sources/TemplateKit/TemplateError.swift
@@ -4,7 +4,7 @@ import Debugging
 public struct TemplateError: Debuggable {
     public let identifier: String
     public let reason: String
-    public var sourceLocation: SourceLocation
+    public var sourceLocation: SourceLocation?
     public var stackTrace: [String]
 
     public init(
@@ -18,31 +18,25 @@ public struct TemplateError: Debuggable {
         self.stackTrace = TemplateError.makeStackTrace()
     }
 
-    internal static func serialize(reason: String, source: TemplateSource) -> TemplateError {
+    internal static func serialize(reason: String, template: TemplateSource, source: SourceLocation) -> TemplateError {
         return TemplateError(
             identifier: "serialize",
-            reason: reason,
-            source: source.makeSourceLocation()
+            reason:  reason + " in " + template.makeReadable(),
+            source: source
         )
     }
 
-    public static func parse(reason: String, source: TemplateSource) -> TemplateError {
+    public static func parse(reason: String, template: TemplateSource, source: SourceLocation) -> TemplateError {
         return TemplateError(
             identifier: "parse",
-            reason: reason,
-            source: source.makeSourceLocation()
+            reason: reason + " in " + template.makeReadable(),
+            source: source
         )
     }
 }
 
 extension TemplateSource {
-    public func makeSourceLocation() -> SourceLocation {
-        return SourceLocation(
-            file: file,
-            function: range.description,
-            line: UInt(line),
-            column: UInt(column),
-            range: Range<UInt>(uncheckedBounds: (lower: UInt(range.lowerBound), upper: UInt(range.upperBound)))
-        )
+    fileprivate func makeReadable() -> String {
+        return "\(file) line: \(line) column: \(column) range: \(range)"
     }
 }


### PR DESCRIPTION
`TemplateKitError` incorrectly used template source as error source. This creates an inability to find where in the source code errors are being generated.