### PR TITLE
add public TemplateData.date var

### DIFF
--- a/Sources/TemplateKit/Data/TemplateData.swift
+++ b/Sources/TemplateKit/Data/TemplateData.swift
@@ -200,6 +200,16 @@ public struct TemplateData: NestedData, Equatable, TemplateDataRepresentable {
             return nil
         }
     }
+    
+    /// Attempts to convert to `Date` or returns `nil`.
+    public var date: Double? {
+        switch storage {
+        case .double(let d):
+            return Date(timeIntervalSince1970: d)
+        default:
+            return nil
+        }
+    }
 
     /// Attempts to convert to `[String: TemplateData]` or returns `nil`.
     public var dictionary: [String: TemplateData]? {

--- a/Sources/TemplateKit/Data/TemplateData.swift
+++ b/Sources/TemplateKit/Data/TemplateData.swift
@@ -202,7 +202,7 @@ public struct TemplateData: NestedData, Equatable, TemplateDataRepresentable {
     }
     
     /// Attempts to convert to `Date` or returns `nil`.
-    public var date: Double? {
+    public var date: Date? {
         switch storage {
         case .double(let d):
             return Date(timeIntervalSince1970: d)

--- a/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
+++ b/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
@@ -13,6 +13,19 @@ class TemplateDataEncoderTests: XCTestCase {
         let data: Double = 3.14
         try XCTAssertEqual(TemplateDataEncoder().testEncode(data), .double(data))
     }
+    
+    func testDate() {
+        let interval: Double = -1000000
+        let date: Date = Date(timeIntervalSince1970: interval)
+        if let data: TemplateData = try? date.convertToTemplateData() {
+            XCTAssertEqual(data.date, date)
+            // note: test purposes only, interval cannot be recovered if not actually a Double(Int)
+            XCTAssertEqual(data.date?.timeIntervalSince1970, interval)
+        } else {
+            XCTFail()
+        }
+    }
+
 
     func testDictionary() {
         let data: [String: String] = ["string": "hello", "foo": "3.14"]
@@ -169,6 +182,7 @@ class TemplateDataEncoderTests: XCTestCase {
     static var allTests = [
         ("testString", testString),
         ("testDouble", testDouble),
+        ("testDate", testDate),
         ("testDictionary", testDictionary),
         ("testNestedDictionary", testNestedDictionary),
         ("testNestedArray", testNestedArray),

--- a/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
+++ b/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
@@ -26,7 +26,6 @@ class TemplateDataEncoderTests: XCTestCase {
         }
     }
 
-
     func testDictionary() {
         let data: [String: String] = ["string": "hello", "foo": "3.14"]
         try XCTAssertEqual(TemplateDataEncoder().testEncode(data), .dictionary([


### PR DESCRIPTION
Since `Date` has been extended with `convertToTemplateData()`, it's been suggested that a convenience for going in reverse might be useful in order to simply `parameter.date` within tags.