### PR TITLE
add modulo (%) infix operator

### DIFF
--- a/Sources/TemplateKit/AST/TemplateExpression.swift
+++ b/Sources/TemplateKit/AST/TemplateExpression.swift
@@ -23,11 +23,17 @@ public enum TemplateExpression: CustomStringConvertible {
         ///
         case multiply
 
-        /// Divids the left value by the right value.
+        /// Divides the left value by the right value.
         ///
         ///     a / b
         ///
         case divide
+
+        /// The remainder from dividing the left value by the right value.
+        ///
+        ///     a % b
+        ///
+        case modulo
 
         /// Checks whether the left value is less than the right value.
         ///
@@ -84,6 +90,7 @@ public enum TemplateExpression: CustomStringConvertible {
             case .subtract: return "-"
             case .multiply: return "*"
             case .divide: return "/"
+            case .modulo: return "%"
             case .lessThan: return "<"
             case .greaterThan: return ">"
             case .lessThanOrEqual: return "<="

--- a/Sources/TemplateKit/Data/TemplateData.swift
+++ b/Sources/TemplateKit/Data/TemplateData.swift
@@ -200,6 +200,16 @@ public struct TemplateData: NestedData, Equatable, TemplateDataRepresentable {
             return nil
         }
     }
+    
+    /// Attempts to convert to `Date` or returns `nil`.
+    public var date: Double? {
+        switch storage {
+        case .double(let d):
+            return Date(timeIntervalSince1970: d)
+        default:
+            return nil
+        }
+    }
 
     /// Attempts to convert to `[String: TemplateData]` or returns `nil`.
     public var dictionary: [String: TemplateData]? {

--- a/Sources/TemplateKit/Data/TemplateData.swift
+++ b/Sources/TemplateKit/Data/TemplateData.swift
@@ -202,7 +202,7 @@ public struct TemplateData: NestedData, Equatable, TemplateDataRepresentable {
     }
     
     /// Attempts to convert to `Date` or returns `nil`.
-    public var date: Double? {
+    public var date: Date? {
         switch storage {
         case .double(let d):
             return Date(timeIntervalSince1970: d)

--- a/Sources/TemplateKit/Data/TemplateData.swift
+++ b/Sources/TemplateKit/Data/TemplateData.swift
@@ -201,16 +201,6 @@ public struct TemplateData: NestedData, Equatable, TemplateDataRepresentable {
         }
     }
     
-    /// Attempts to convert to `Date` or returns `nil`.
-    public var date: Date? {
-        switch storage {
-        case .double(let d):
-            return Date(timeIntervalSince1970: d)
-        default:
-            return nil
-        }
-    }
-
     /// Attempts to convert to `[String: TemplateData]` or returns `nil`.
     public var dictionary: [String: TemplateData]? {
         switch storage {

--- a/Sources/TemplateKit/Pipeline/TemplateSerializer.swift
+++ b/Sources/TemplateKit/Pipeline/TemplateSerializer.swift
@@ -116,6 +116,7 @@ public final class TemplateSerializer {
                 case .subtract: return .double(leftDouble - rightDouble)
                 case .multiply: return .double(leftDouble * rightDouble)
                 case .divide: return .double(leftDouble / rightDouble)
+                case .modulo: return .double(leftDouble.truncatingRemainder(dividingBy: rightDouble))
                 case .greaterThan: return .bool(leftDouble > rightDouble)
                 case .lessThan: return .bool(leftDouble < rightDouble)
                 default:

--- a/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
+++ b/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
@@ -13,6 +13,19 @@ class TemplateDataEncoderTests: XCTestCase {
         let data: Double = 3.14
         try XCTAssertEqual(TemplateDataEncoder().testEncode(data), .double(data))
     }
+    
+    func testDate() {
+        let interval: Double = -1000000
+        let date: Date = Date(timeIntervalSince1970: interval)
+        if let data: TemplateData = try? date.convertToTemplateData() {
+            XCTAssertEqual(data.date, date)
+            // note: test purposes only, interval cannot be recovered if not actually a Double(Int)
+            XCTAssertEqual(data.date?.timeIntervalSince1970, interval)
+        } else {
+            XCTFail()
+        }
+    }
+
 
     func testDictionary() {
         let data: [String: String] = ["string": "hello", "foo": "3.14"]
@@ -169,6 +182,7 @@ class TemplateDataEncoderTests: XCTestCase {
     static var allTests = [
         ("testString", testString),
         ("testDouble", testDouble),
+        ("testDate", testDate),
         ("testDictionary", testDictionary),
         ("testNestedDictionary", testNestedDictionary),
         ("testNestedArray", testNestedArray),

--- a/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
+++ b/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
@@ -169,7 +169,6 @@ class TemplateDataEncoderTests: XCTestCase {
     static var allTests = [
         ("testString", testString),
         ("testDouble", testDouble),
-        ("testDate", testDate),
         ("testDictionary", testDictionary),
         ("testNestedDictionary", testNestedDictionary),
         ("testNestedArray", testNestedArray),

--- a/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
+++ b/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
@@ -14,18 +14,6 @@ class TemplateDataEncoderTests: XCTestCase {
         try XCTAssertEqual(TemplateDataEncoder().testEncode(data), .double(data))
     }
     
-    func testDate() {
-        let interval: Double = -1000000
-        let date: Date = Date(timeIntervalSince1970: interval)
-        if let data: TemplateData = try? date.convertToTemplateData() {
-            XCTAssertEqual(data.date, date)
-            // note: test purposes only, interval cannot be recovered if not actually a Double(Int)
-            XCTAssertEqual(data.date?.timeIntervalSince1970, interval)
-        } else {
-            XCTFail()
-        }
-    }
-
     func testDictionary() {
         let data: [String: String] = ["string": "hello", "foo": "3.14"]
         try XCTAssertEqual(TemplateDataEncoder().testEncode(data), .dictionary([

--- a/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
+++ b/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
@@ -26,7 +26,6 @@ class TemplateDataEncoderTests: XCTestCase {
         }
     }
 
-
     func testDictionary() {
         let data: [String: String] = ["string": "hello", "foo": "3.14"]
         try XCTAssertEqual(TemplateDataEncoder().testEncode(data), .dictionary([


### PR DESCRIPTION
We're working with `Double`s here, so as long as people use *sane* values it should work as they expect (according to Apple).

NOTE: Because I screwed up in not pre-branching, this should probably be merged *before* https://github.com/vapor/template-kit/pull/18 so as not to create a conflict with `TemplateData` or `TemplateDataEncoderTests`.