### PR TITLE
Fixed out-of-bounds crash with #date tag

### DIFF
--- a/Sources/TemplateKit/Tag/DateFormat.swift
+++ b/Sources/TemplateKit/Tag/DateFormat.swift
@@ -19,7 +19,11 @@ public final class DateFormat: TagRenderer {
         /// Assume the date is a floating point number
         let date = Date(timeIntervalSinceReferenceDate: tag.parameters[0].double ?? 0)
         /// Set format as the second param or default to ISO-8601 format.
-        formatter.dateFormat = tag.parameters[1].string ?? "yyyy-MM-dd HH:mm:ss"
+        if tag.parameters.count == 2, let param = tag.parameters[2].string {
+            formatter.dateFormat = param
+        } else {
+            formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        }
 
         /// Return formatted date
         return Future.map(on: tag) { .string(formatter.string(from: date)) }

--- a/Sources/TemplateKit/Tag/DateFormat.swift
+++ b/Sources/TemplateKit/Tag/DateFormat.swift
@@ -19,7 +19,7 @@ public final class DateFormat: TagRenderer {
         /// Assume the date is a floating point number
         let date = Date(timeIntervalSinceReferenceDate: tag.parameters[0].double ?? 0)
         /// Set format as the second param or default to ISO-8601 format.
-        if tag.parameters.count == 2, let param = tag.parameters[2].string {
+        if tag.parameters.count == 2, let param = tag.parameters[1].string {
             formatter.dateFormat = param
         } else {
             formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"


### PR DESCRIPTION
The `#date` tag did not properly default the second parameter.

Using `#date(someDate)` would cause an out-of-bound error on the `tag.parameters` array, since out-of-bound indexes do _not_ return optionals.

This checks that the parameters array has two elements before trying to get the second parameter.