### PR TITLE
improve render caching, fixes #24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /Packages
 /*.xcodeproj
 Package.resolved
+DerivedData
+

--- a/Sources/TemplateKit/Data/TemplateDataEncoder.swift
+++ b/Sources/TemplateKit/Data/TemplateDataEncoder.swift
@@ -228,4 +228,3 @@ fileprivate final class _TemplateDataUnkeyedEncoder: UnkeyedEncodingContainer {
         try value.encode(to: encoder)
     }
 }
-

--- a/Sources/TemplateKit/Data/TemplateDataEncoder.swift
+++ b/Sources/TemplateKit/Data/TemplateDataEncoder.swift
@@ -176,8 +176,13 @@ fileprivate final class _TemplateDataKeyedEncoder<K>: KeyedEncodingContainerProt
     }
 
     func encode<T>(_ value: T, forKey key: K) throws where T: Encodable {
-        let encoder = _TemplateDataEncoder(context: context, codingPath: codingPath + [key])
-        try value.encode(to: encoder)
+        if let data = value as? TemplateDataRepresentable {
+            try context.data.set(to: .data(data.convertToTemplateData()), at: codingPath + [key])
+        } else {
+            
+            let encoder = _TemplateDataEncoder(context: context, codingPath: codingPath + [key])
+            try value.encode(to: encoder)
+        }
     }
 }
 

--- a/Sources/TemplateKit/Pipeline/ASTCache.swift
+++ b/Sources/TemplateKit/Pipeline/ASTCache.swift
@@ -1,7 +1,7 @@
 /// Caches a `TemplateRenderer`'s parsed ASTs.
 public struct ASTCache {
     /// Internal AST storage.
-    internal var storage: [Int: [TemplateSyntax]]
+    internal var storage: [String: [TemplateSyntax]]
 
     /// Creates a new `ASTCache`.
     public init() {

--- a/Sources/TemplateKit/Pipeline/TemplateRenderer.swift
+++ b/Sources/TemplateKit/Pipeline/TemplateRenderer.swift
@@ -128,6 +128,7 @@ extension TemplateRenderer {
     }
     
     private func _parse(_ template: Data, file: String) throws -> [TemplateSyntax] {
+        print("PARSE: \(file)")
         let scanner = TemplateByteScanner(data: template, file: file)
         return try parser.parse(scanner: scanner)
     }

--- a/Sources/TemplateKit/Tag/DateFormat.swift
+++ b/Sources/TemplateKit/Tag/DateFormat.swift
@@ -17,7 +17,7 @@ public final class DateFormat: TagRenderer {
 
         let formatter = DateFormatter()
         /// Assume the date is a floating point number
-        let date = Date(timeIntervalSinceReferenceDate: tag.parameters[0].double ?? 0)
+        let date = Date(timeIntervalSince1970: tag.parameters[0].double ?? 0)
         /// Set format as the second param or default to ISO-8601 format.
         if tag.parameters.count == 2, let param = tag.parameters[1].string {
             formatter.dateFormat = param

--- a/Sources/TemplateKit/ViewRenderer.swift
+++ b/Sources/TemplateKit/ViewRenderer.swift
@@ -1,6 +1,5 @@
 /// Renders an Encodable object into a `View`.
 public protocol ViewRenderer: class {
-
     /// For view renderers that use a cache to optimize view loads, use this variable to toggle whether or not cache should be implemented
     ///
     /// Normally, cache is disabled in development so views can be tested w/o recompilation.
@@ -14,18 +13,4 @@ public protocol ViewRenderer: class {
     ///     - context: `Encodable` item that will be encoded to `TemplateData` and used as template context.
     /// - returns: `Future` containing the rendered `View`.
     func render<E>(_ path: String, _ context: E) -> Future<View> where E: Encodable
-}
-
-extension ViewRenderer where Self: TemplateRenderer {
-    /// See `ViewRenderer`.
-    public var shouldCache: Bool {
-        get { return astCache != nil }
-        set {
-            if newValue {
-                astCache = .init()
-            } else {
-                astCache = nil
-            }
-        }
-    }
 }


### PR DESCRIPTION
Fixes an issue where `render(_:_:)` would not cache parsed ASTs. This method is used by `TemplateEmbed` which resulted in excessive file loading and parsing for views that embedded other views. 