### PR TITLE
1.1 release

### DIFF
--- a/Sources/TemplateKit/AST/TemplateConditional.swift
+++ b/Sources/TemplateKit/AST/TemplateConditional.swift
@@ -33,9 +33,9 @@ public final class TemplateConditional: CustomStringConvertible {
     /// See `CustomStringConvertible`.
     public var description: String {
         if let next = self.next {
-            return "if (\(condition)) { \(body) } else { \(next) }"
+            return "\(condition), \(body), \(next)"
         } else {
-            return "if (\(condition)) { \(body) }"
+            return "\(condition), \(body), nil"
         }
     }
 }

--- a/Sources/TemplateKit/AST/TemplateDataContext.swift
+++ b/Sources/TemplateKit/AST/TemplateDataContext.swift
@@ -2,9 +2,13 @@
 public final class TemplateDataContext {
     /// The referenced `TemplateData`
     public var data: TemplateData
+    
+    /// User-defined storage.
+    public var userInfo: [AnyHashable: Any]
 
     /// Create a new `TemplateDataContext`.
-    public init(data: TemplateData) {
+    public init(data: TemplateData, userInfo: [AnyHashable: Any] = [:]) {
         self.data = data
+        self.userInfo = userInfo
     }
 }

--- a/Sources/TemplateKit/AST/TemplateExpression.swift
+++ b/Sources/TemplateKit/AST/TemplateExpression.swift
@@ -82,6 +82,24 @@ public enum TemplateExpression: CustomStringConvertible {
         ///     a || b
         ///
         case or
+        
+        public var order: Int {
+            switch self {
+            case .add: return 4
+            case .subtract: return 4
+            case .multiply: return 3
+            case .divide: return 3
+            case .modulo: return 3
+            case .lessThan: return 5
+            case .greaterThan: return 5
+            case .lessThanOrEqual: return 5
+            case .greaterThanOrEqual: return 5
+            case .equal: return 5
+            case .notEqual: return 5
+            case .and: return 6
+            case .or: return 6
+            }
+        }
 
         /// See `CustomStringConvertible`.
         public var description: String {

--- a/Sources/TemplateKit/AST/TemplateSyntax.swift
+++ b/Sources/TemplateKit/AST/TemplateSyntax.swift
@@ -21,16 +21,21 @@ public struct TemplateSyntax: CustomStringConvertible {
     public var description: String {
         switch type {
         case .raw(let source):
-            let string = String(data: source.data, encoding: .utf8) ?? "n/a"
-            return "Raw: \(string)"
-        case .tag(let tag): return "Tag: \(tag)"
-        case .identifier(let name): return "Identifier: \(name.path)"
-        case .expression(let expr): return "Expression: (\(expr))"
-        case .constant(let const): return "Contstant: \(const)"
-        case .embed(let embed): return "Embed: \(embed.path)"
-        case .conditional(let cond): return "Conditional: \(cond))"
-        case .iterator(let it): return "Iterator: \(it)"
-        case .custom: return "Custom: ()"
+            var string = String(data: source.data, encoding: .utf8) ?? "n/a"
+            string = string.replacingOccurrences(of: "\n", with: "\\n")
+            return "raw(\"\(string)\")"
+        case .tag(let tag):
+            let params = tag.parameters.map { $0.description }.joined(separator: ", ")
+            return "tag(\"\(tag.name)\", [\(params)])"
+        case .identifier(let name):
+            let path = name.path.map { $0.stringValue }.joined(separator: ".")
+            return "id(\(path))"
+        case .expression(let expr): return "(\(expr))"
+        case .constant(let const): return "\(const)"
+        case .embed(let embed): return "embed\(embed.path)"
+        case .conditional(let cond): return "cond(\(cond))"
+        case .iterator(let it): return "while\(it)"
+        case .custom: return "custom()"
         }
     }
 }

--- a/Sources/TemplateKit/Pipeline/TemplateRenderer.swift
+++ b/Sources/TemplateKit/Pipeline/TemplateRenderer.swift
@@ -45,40 +45,27 @@ extension TemplateRenderer {
 }
 
 extension TemplateRenderer {
-    // MARK: Render Path
-    
-    /// Loads and renders a raw template at the supplied path using an empty context.
-    ///
-    /// - parameters:
-    ///     - path: Path to file contianing raw template bytes.
-    /// - returns: `Future` containing the rendered `View`.
-    public func render(_ path: String) -> Future<View> {
-        return render(path, .null)
-    }
-    
-    /// Renders the template bytes into a view using the supplied `Encodable` object as context.
-    ///
-    /// - parameters:
-    ///     - path: Path to file contianing raw template bytes.
-    ///     - context: `Encodable` item that will be encoded to `TemplateData` and used as template context.
-    /// - returns: `Future` containing the rendered `View`.
-    public func render<E>(_ path: String, _ context: E) -> Future<View> where E: Encodable {
+    /// See `ViewRenderer`.
+    public func render<E>(_ path: String, _ context: E, userInfo: [AnyHashable: Any]) -> Future<View> where E: Encodable {
         do {
             return try TemplateDataEncoder().encode(context, on: self.container).flatMap { context in
-                return self.render(path, context)
+                return self.render(path, context, userInfo: userInfo)
             }
         } catch {
             return container.future(error: error)
         }
     }
     
+    // MARK: TemplateData
+    
     /// Loads and renders a raw template at the supplied path.
     ///
     /// - parameters:
     ///     - path: Path to file contianing raw template bytes.
     ///     - context: `TemplateData` to expose as context to the template.
+    ///     - userInfo: User-defined storage.
     /// - returns: `Future` containing the rendered `View`.
-    public func render(_ path: String, _ context: TemplateData) -> Future<View> {
+    public func render(_ path: String, _ context: TemplateData, userInfo: [AnyHashable: Any] = [:]) -> Future<View> {
         do {
             let path = path.hasSuffix(templateFileEnding) ? path : path + templateFileEnding
             let absolutePath = path.hasPrefix("/") ? path : relativeDirectory + path
@@ -96,7 +83,7 @@ extension TemplateRenderer {
                 ast = try _parse(data, file: absolutePath)
                 astCache?.storage[absolutePath] = ast
             }
-            return _serialize(context, ast, file: absolutePath)
+            return _serialize(context, ast, file: absolutePath, userInfo: userInfo)
         } catch {
             return container.future(error: error)
         }
@@ -109,11 +96,12 @@ extension TemplateRenderer {
     /// - parameters:
     ///     - template: Raw template bytes.
     ///     - context: `Encodable` item that will be encoded to `TemplateData` and used as template context.
+    ///     - userInfo: User-defined storage.
     /// - returns: `Future` containing the rendered `View`.
-    public func render<E>(template: Data, _ context: E) -> Future<View> where E: Encodable {
+    public func render<E>(template: Data, _ context: E, userInfo: [AnyHashable: Any] = [:]) -> Future<View> where E: Encodable {
         do {
             return try TemplateDataEncoder().encode(context, on: self.container).flatMap { context in
-                return self.render(template: template, context)
+                return self.render(template: template, context, userInfo: userInfo)
             }
         } catch {
             return container.future(error: error)
@@ -126,11 +114,12 @@ extension TemplateRenderer {
     ///     - template: Raw template bytes.
     ///     - context: `TemplateData` to expose as context to the template.
     ///     - file: Template description, will be used for generating errors.
+    ///     - userInfo: User-defined storage.
     /// - returns: `Future` containing the rendered `View`.
-    public func render(template: Data, _ context: TemplateData, file: String? = nil) -> Future<View> {
+    public func render(template: Data, _ context: TemplateData, file: String? = nil, userInfo: [AnyHashable: Any] = [:]) -> Future<View> {
         let path = file ?? "template"
         do {
-            return try _serialize(context, _parse(template, file: path), file: path)
+            return try _serialize(context, _parse(template, file: path), file: path, userInfo: userInfo)
         } catch {
             return container.future(error: error)
         }
@@ -139,10 +128,10 @@ extension TemplateRenderer {
     // MARK: Private
     
     /// Serializes an AST + Context
-    private func _serialize(_ context: TemplateData, _ ast: [TemplateSyntax], file: String) -> Future<View> {
+    private func _serialize(_ context: TemplateData, _ ast: [TemplateSyntax], file: String, userInfo: [AnyHashable: Any]) -> Future<View> {
         let serializer = TemplateSerializer(
             renderer: self,
-            context: .init(data: context),
+            context: .init(data: context, userInfo: userInfo),
             using: self.container
         )
         return serializer.serialize(ast: ast)

--- a/Sources/TemplateKit/Pipeline/TemplateRenderer.swift
+++ b/Sources/TemplateKit/Pipeline/TemplateRenderer.swift
@@ -139,7 +139,6 @@ extension TemplateRenderer {
     
     /// Parses data to AST.
     private func _parse(_ template: Data, file: String) throws -> [TemplateSyntax] {
-        print("PARSE: \(file)")
         let scanner = TemplateByteScanner(data: template, file: file)
         return try parser.parse(scanner: scanner)
     }

--- a/Sources/TemplateKit/Pipeline/TemplateSerializer.swift
+++ b/Sources/TemplateKit/Pipeline/TemplateSerializer.swift
@@ -108,23 +108,44 @@ public final class TemplateSerializer {
             case .and: return .bool(left.bool != false && right.bool != false)
             case .or: return .bool(left.bool != false || right.bool != false)
             default:
-                guard let leftDouble = left.double, let rightDouble = right.double else {
-                    return .bool(false)
-                }
-                switch infix {
-                case .add: return .double(leftDouble + rightDouble)
-                case .subtract: return .double(leftDouble - rightDouble)
-                case .multiply: return .double(leftDouble * rightDouble)
-                case .divide: return .double(leftDouble / rightDouble)
-                case .modulo: return .double(leftDouble.truncatingRemainder(dividingBy: rightDouble))
-                case .greaterThan: return .bool(leftDouble > rightDouble)
-                case .lessThan: return .bool(leftDouble < rightDouble)
+                switch (left.storage, right.storage) {
+                case (.int(let a), .int(let b)):
+                    // integer math
+                    switch infix {
+                    case .add: return .int(a + b)
+                    case .subtract: return .int(a - b)
+                    case .multiply: return .int(a * b)
+                    case .divide: return .int(a / b)
+                    case .modulo: return .int(a % b)
+                    case .greaterThan: return .bool(a > b)
+                    case .lessThan: return .bool(a < b)
+                    default:
+                        throw TemplateKitError(
+                            identifier: "renderInfix",
+                            reason: "Unsupported infix operator: \(infix).",
+                            source: source
+                        )
+                    }
                 default:
-                    throw TemplateKitError(
-                        identifier: "renderInfix",
-                        reason: "Unsupported infix operator: \(infix).",
-                        source: source
-                    )
+                    // default to double conversion math
+                    guard let leftDouble = left.double, let rightDouble = right.double else {
+                        return .bool(false)
+                    }
+                    switch infix {
+                    case .add: return .double(leftDouble + rightDouble)
+                    case .subtract: return .double(leftDouble - rightDouble)
+                    case .multiply: return .double(leftDouble * rightDouble)
+                    case .divide: return .double(leftDouble / rightDouble)
+                    case .modulo: return .double(leftDouble.truncatingRemainder(dividingBy: rightDouble))
+                    case .greaterThan: return .bool(leftDouble > rightDouble)
+                    case .lessThan: return .bool(leftDouble < rightDouble)
+                    default:
+                        throw TemplateKitError(
+                            identifier: "renderInfix",
+                            reason: "Unsupported infix operator: \(infix).",
+                            source: source
+                        )
+                    }
                 }
             }
         }

--- a/Sources/TemplateKit/ViewRenderer.swift
+++ b/Sources/TemplateKit/ViewRenderer.swift
@@ -11,6 +11,29 @@ public protocol ViewRenderer: class {
     /// - parameters:
     ///     - path: Path to file contianing raw template bytes.
     ///     - context: `Encodable` item that will be encoded to `TemplateData` and used as template context.
+    ///     - userInfo: User-defined storage.
     /// - returns: `Future` containing the rendered `View`.
-    func render<E>(_ path: String, _ context: E) -> Future<View> where E: Encodable
+    func render<E>(_ path: String, _ context: E, userInfo: [AnyHashable: Any]) -> Future<View> where E: Encodable
+}
+
+extension ViewRenderer {
+    /// Renders the template bytes into a view using the supplied `Encodable` object as context.
+    ///
+    /// - parameters:
+    ///     - path: Path to file contianing raw template bytes.
+    ///     - context: `Encodable` item that will be encoded to `TemplateData` and used as template context.
+    /// - returns: `Future` containing the rendered `View`.
+    public func render<E>(_ path: String, _ context: E) -> Future<View> where E: Encodable {
+        return render(path, context, userInfo: [:])
+    }
+    
+    /// Loads and renders a raw template at the supplied path using an empty context.
+    ///
+    /// - parameters:
+    ///     - path: Path to file contianing raw template bytes.
+    ///     - userInfo: User-defined storage.
+    /// - returns: `Future` containing the rendered `View`.
+    public func render(_ path: String, userInfo: [AnyHashable: Any] = [:]) -> Future<View> {
+        return render(path, Dictionary<String, String>(), userInfo: userInfo)
+    }
 }


### PR DESCRIPTION
This PR allows for `userInfo` to be  passed to render calls. Related to #28. 

```swift
return req.view().render("welcome", ["name": "Vapor"], userInfo: ["foo": "bar"])
```

You can then access this `userInfo` in `TagRenderer`.

```swift
final class FooTag: TagRenderer {
    func render(_ tag: TagContext) -> ... { 
        print(tag.context.userInfo["foo"])
    }
}
```