### PR TITLE
document TemplateExpression public var

### DIFF
--- a/Sources/TemplateKit/AST/TemplateExpression.swift
+++ b/Sources/TemplateKit/AST/TemplateExpression.swift
@@ -82,7 +82,8 @@ public enum TemplateExpression: CustomStringConvertible {
         ///     a || b
         ///
         case or
-        
+
+        /// Operator precedence order (used internally by `LeafParser` when extracting parameters).
         public var order: Int {
             switch self {
             case .add: return 4


### PR DESCRIPTION
Adds API documentation to `TemplateExpression` for exposed var `order`.
(feel free to modify, but should probably be documented in some way if exposed)