### PR TITLE
Add dump tag

### DIFF
--- a/Sources/TemplateKit/Tag/Dump.swift
+++ b/Sources/TemplateKit/Tag/Dump.swift
@@ -1,0 +1,18 @@
+/// Print debug information about variables
+///
+///     dump(<item>)
+///
+public final class Dump: TagRenderer {
+    /// See `TagRenderer`.
+    public init() {}
+
+    /// See `TagRenderer`.
+    public func render(tag: TagContext) throws -> EventLoopFuture<TemplateData> {
+        try tag.requireParameterCount(1)
+
+        var dumpString = ""
+        debugPrint(tag.parameters[0], to: &dumpString)
+
+        return tag.future(.string(dumpString))
+    }
+}

--- a/Sources/TemplateKit/Tag/TagRenderer.swift
+++ b/Sources/TemplateKit/Tag/TagRenderer.swift
@@ -23,6 +23,7 @@ public var defaultTags: [String: TagRenderer] {
         "count": Count(),
         "set": Var(),
         "get": Raw(),
-        "date": DateFormat()
+        "date": DateFormat(),
+        "dump": Dump()
     ]
 }


### PR DESCRIPTION
Sometimes, it's good to know some more information about the variables inside the templates. Therefore, I considered a "dump"-tag useful. With my code, I wanted to introduce this concept. Maybe there is something better than `debugPrint` - I'm open for your feedback and input :)