### PR TITLE
swift 5 updates; fix buffer pointers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.1
 import PackageDescription
 
 let package = Package(

--- a/circle.yml
+++ b/circle.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - run:
           name: Clone Vapor
-          command: git clone -b master https://github.com/vapor/vapor.git
+          command: git clone -b 3 https://github.com/vapor/vapor.git
           working_directory: ~/
       - run:
           name: Switch Vapor to this TemplateKit revision


### PR DESCRIPTION
The pointer from `withUnsafeBytes` should not be held onto past the closure's lifetime. Swift 5 actually makes doing this an error. 