### PR TITLE
Conform `Data` to `TemplateDataRepresentable` by encoding it has a hex-encoded string

### DIFF
--- a/Sources/TemplateKit/Data/TemplateDataEncoder.swift
+++ b/Sources/TemplateKit/Data/TemplateDataEncoder.swift
@@ -5,6 +5,11 @@ public final class TemplateDataEncoder {
 
     /// Encode an `Encodable` item to `TemplateData`.
     public func encode<E>(_ encodable: E, on worker: Worker) throws -> Future<TemplateData> where E: Encodable {
+        if let representable = encodable as? TemplateDataRepresentable {
+            // Shortcut if the argument is "trivially" representable as `TemplateData`.
+            return worker.future(try representable.convertToTemplateData())
+        }
+        
         let encoder = _TemplateDataEncoder(context: .init(data: .dictionary([:]), on: worker))
         try encodable.encode(to: encoder)
         return encoder.context.data.resolve(on: worker)

--- a/Sources/TemplateKit/Data/TemplateDataRepresentable.swift
+++ b/Sources/TemplateKit/Data/TemplateDataRepresentable.swift
@@ -14,6 +14,13 @@ extension String: TemplateDataRepresentable {
     }
 }
 
+extension Data: TemplateDataRepresentable {
+    /// See `TemplateDataRepresentable`
+    public func convertToTemplateData() throws -> TemplateData {
+        return .string(self.hexEncodedString())
+    }
+}
+
 extension FixedWidthInteger {
     /// See `TemplateDataRepresentable`
     public func convertToTemplateData() throws -> TemplateData {

--- a/Sources/TemplateKit/Data/TemplateDataRepresentable.swift
+++ b/Sources/TemplateKit/Data/TemplateDataRepresentable.swift
@@ -96,3 +96,17 @@ extension Date: TemplateDataRepresentable {
         return .double(timeIntervalSince1970)
     }
 }
+
+extension Array: TemplateDataRepresentable where Element: TemplateDataRepresentable {
+    /// See `TemplateDataRepresentable`
+    public func convertToTemplateData() throws -> TemplateData {
+        return try .array(self.map { try $0.convertToTemplateData() })
+    }
+}
+
+extension Dictionary: TemplateDataRepresentable where Key == String, Value: TemplateDataRepresentable {
+    /// See `TemplateDataRepresentable`
+    public func convertToTemplateData() throws -> TemplateData {
+        return try .dictionary(self.mapValues { try $0.convertToTemplateData() })
+    }
+}


### PR DESCRIPTION
Motivation: encoding large arrays of primitive types as `TemplateData` is fairly slow. The default encoding strategy for `Data` is to encode it as an array of bytes, which falls victim to that.

This PR avoids an accidental slowdown for the case where a model contains a `Data` field that gets encoded by default by the `TemplateDataEncoder`. (In one case, this change has reduced render times on a large page from ~3.75s to ~460ms in a Release build.)

In addition, encoding `Data` as a hex-encoded string arguably makes more sense than encoding it as an array of integers.