### PR TITLE
 Fixed buffer underflow access for TemplateByteScanner.peek()

### DIFF
--- a/Sources/TemplateKit/Pipeline/TemplateByteScanner.swift
+++ b/Sources/TemplateKit/Pipeline/TemplateByteScanner.swift
@@ -46,7 +46,7 @@ public final class TemplateByteScanner {
     /// - returns:
     ///     - Byte requested if not past end of data.
     public func peek(by amount: Int = 0) -> UInt8? {
-        guard pointer + amount < buffer.count else {
+        guard pointer + amount < buffer.count && pointer + amount >= 0 else {
             return nil
         }
         return buffer[pointer + amount]

--- a/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
+++ b/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
@@ -220,6 +220,7 @@ class TemplateDataEncoderTests: XCTestCase {
         ("testNestedEncodable", testNestedEncodable),
         ("testGH10", testGH10),
         ("testGH20", testGH20),
+        ("testTemplabeByteScannerPeak", testTemplabeByteScannerPeak),
     ]
 }
 

--- a/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
+++ b/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
@@ -200,6 +200,14 @@ class TemplateDataEncoderTests: XCTestCase {
         print(formatter.string(from: date))
         XCTAssertEqual(String(data: view.data, encoding: .utf8), formatter.string(from: date))
     }
+    
+    func testTemplabeByteScannerPeak() {
+        let scanner = TemplateByteScanner(data: Data(), file: "empty")
+        
+        XCTAssertNil(scanner.peek(by: 0))
+        XCTAssertNil(scanner.peek(by: -1))
+        XCTAssertNil(scanner.peek(by: 1))
+    }
 
     static var allTests = [
         ("testString", testString),


### PR DESCRIPTION
The leaf code makes the following call:

```swift
let isEntirelyCommentLine: Bool = (peek(by: -4) == .newLine)
```

I have encountered times when this call causes an underflow _(pointer + offset < 0)_, which caused the peek code to crash.  I've added an additional check to the guard statement to ensure that underflow requests do not crash the code mimicking the existing support for overflow requests.