### PR TITLE
Speed up `TemplateDataEncoder` significantly.

### DIFF
--- a/Sources/TemplateKit/Data/TemplateDataRepresentable.swift
+++ b/Sources/TemplateKit/Data/TemplateDataRepresentable.swift
@@ -14,6 +14,13 @@ extension String: TemplateDataRepresentable {
     }
 }
 
+extension Data: TemplateDataRepresentable {
+    /// See `TemplateDataRepresentable`
+    public func convertToTemplateData() throws -> TemplateData {
+        return .data(self)
+    }
+}
+
 extension FixedWidthInteger {
     /// See `TemplateDataRepresentable`
     public func convertToTemplateData() throws -> TemplateData {
@@ -54,6 +61,20 @@ extension OptionalType {
 }
 
 extension Optional: TemplateDataRepresentable { }
+
+extension Array: TemplateDataRepresentable where Element: TemplateDataRepresentable {
+    /// See `TemplateDataRepresentable`
+    public func convertToTemplateData() throws -> TemplateData {
+        return try .array(self.map { try $0.convertToTemplateData() })
+    }
+}
+
+extension Dictionary: TemplateDataRepresentable where Key == String, Value: TemplateDataRepresentable {
+    /// See `TemplateDataRepresentable`
+    public func convertToTemplateData() throws -> TemplateData {
+        return try .dictionary(self.mapValues { try $0.convertToTemplateData() })
+    }
+}
 
 extension Bool: TemplateDataRepresentable {
     /// See `TemplateDataRepresentable`

--- a/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
+++ b/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
@@ -133,7 +133,7 @@ class TemplateDataEncoderTests: XCTestCase {
                 case bar
             }
 
-            override func encode(to encoder: Encoder) throws {
+            func encode(to encoder: Encoder) throws {
                 // Note: `super` will also call `encoder.container(keyedBy:)`; we want to ensure that the data written
                 // by `super` will still be present in the final dictionary.
                 try super.encode(to: encoder)
@@ -159,7 +159,7 @@ class TemplateDataEncoderTests: XCTestCase {
                 case bar
             }
 
-            override func encode(to encoder: Encoder) throws {
+            func encode(to encoder: Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 try container.encode(bar, forKey: .bar)
                 try super.encode(to: container.superEncoder())

--- a/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
+++ b/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
@@ -133,7 +133,7 @@ class TemplateDataEncoderTests: XCTestCase {
                 case bar
             }
 
-            func encode(to encoder: Encoder) throws {
+            override func encode(to encoder: Encoder) throws {
                 // Note: `super` will also call `encoder.container(keyedBy:)`; we want to ensure that the data written
                 // by `super` will still be present in the final dictionary.
                 try super.encode(to: encoder)
@@ -159,7 +159,7 @@ class TemplateDataEncoderTests: XCTestCase {
                 case bar
             }
 
-            func encode(to encoder: Encoder) throws {
+            override func encode(to encoder: Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
                 try container.encode(bar, forKey: .bar)
                 try super.encode(to: container.superEncoder())

--- a/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
+++ b/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
@@ -125,11 +125,20 @@ class TemplateDataEncoderTests: XCTestCase {
     func testEncodeSuperCustomImplementation() {
         class A: Encodable {
             var foo = "foo"
+
+            enum CodingKeys: String, CodingKey {
+                case foo
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(foo, forKey: .foo)
+            }
         }
         class B: A {
             var bar = "bar"
 
-            enum CodingKeys: String, CodingKey {
+            enum SubclassCodingKeys: String, CodingKey {
                 case bar
             }
 
@@ -137,7 +146,7 @@ class TemplateDataEncoderTests: XCTestCase {
                 // Note: `super` will also call `encoder.container(keyedBy:)`; we want to ensure that the data written
                 // by `super` will still be present in the final dictionary.
                 try super.encode(to: encoder)
-                var container = encoder.container(keyedBy: CodingKeys.self)
+                var container = encoder.container(keyedBy: SubclassCodingKeys.self)
                 try container.encode(bar, forKey: .bar)
             }
         }
@@ -151,16 +160,25 @@ class TemplateDataEncoderTests: XCTestCase {
     func testEncodeSuperCustomImplementationWithSuperEncoder1() {
         class A: Encodable {
             var foo = "foo"
+
+            enum CodingKeys: String, CodingKey {
+                case foo
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(foo, forKey: .foo)
+            }
         }
         class B: A {
             var bar = "bar"
 
-            enum CodingKeys: String, CodingKey {
+            enum SubclassCodingKeys: String, CodingKey {
                 case bar
             }
 
             override func encode(to encoder: Encoder) throws {
-                var container = encoder.container(keyedBy: CodingKeys.self)
+                var container = encoder.container(keyedBy: SubclassCodingKeys.self)
                 try container.encode(bar, forKey: .bar)
                 try super.encode(to: container.superEncoder())
             }


### PR DESCRIPTION
Results:

- Before the optimizations, each invocation inside `measure` takes about 4s on my Core i7-6700k.
- After conforming `Data` to `TemplateDataRepresentable`, each invocation inside `measure` takes about 0.2s.
- After rewriting `TemplateDataEncoder`, the runtime halves again to 0.1s. (`NestedData` is fairly inefficient, especially for "deeper" hierarchies.)

Screenshot (including the improvements from https://github.com/vapor/core/pull/199):
<img width="1398" alt="Screen Shot 2019-04-01 at 11 12 50" src="https://user-images.githubusercontent.com/117466/55316674-35aacd80-546f-11e9-92b5-77dec4488234.png">
