### PR TITLE
Don't throw an error when trying to iterate on a null key

### DIFF
--- a/Sources/TemplateKit/Pipeline/TemplateSerializer.swift
+++ b/Sources/TemplateKit/Pipeline/TemplateSerializer.swift
@@ -225,7 +225,7 @@ public final class TemplateSerializer {
                 }
             }
             
-            guard !(data.isNull) else {
+            guard !data.isNull else {
                 return Future.map(on: self.container) { .null }
             }
 

--- a/Sources/TemplateKit/Pipeline/TemplateSerializer.swift
+++ b/Sources/TemplateKit/Pipeline/TemplateSerializer.swift
@@ -224,6 +224,10 @@ public final class TemplateSerializer {
                     return .data(data)
                 }
             }
+            
+            guard !(data.isNull) else {
+                return Future.map(on: self.container) { .null }
+            }
 
             guard let data = data.array else {
                 throw TemplateKitError(


### PR DESCRIPTION
Iterating on an undefined variable causes an error. This code: 

```#for(item in context.allItems) {```

Where `context.allItems` is not defined results in a confusing error message:

`"Could not convert iterator data to array."`

Vapor should allow iteration on undefined variables by doing nothing.