### PR TITLE
Add containsKey tag

### DIFF
--- a/Sources/TemplateKit/Tag/ContainsKey.swift
+++ b/Sources/TemplateKit/Tag/ContainsKey.swift
@@ -1,0 +1,27 @@
+/// Returns `true` if the supplied dictionary contains a given key.
+///
+///     containsKey(<dictionary>, <string>
+///
+public final class ContainsKey: TagRenderer {
+    /// Creates a new `Contains` tag renderer.
+    public init() {}
+
+    /// See `TagRenderer`.
+    public func render(tag: TagContext) throws -> Future<TemplateData> {
+        /// Require two parameters.
+        try tag.requireParameterCount(2)
+
+        let res: TemplateData
+
+        /// Convert first param to a dictionary and second to string or return false.
+        if let dictionary = tag.parameters[0].dictionary,
+            let compare = tag.parameters[1].string {
+            /// Return `true` if the dictionary contains the key.
+            res = .bool(dictionary.keys.contains(compare))
+        } else {
+            res = .bool(false)
+        }
+
+        return Future.map(on: tag) { res }
+    }
+}

--- a/Sources/TemplateKit/Tag/TagRenderer.swift
+++ b/Sources/TemplateKit/Tag/TagRenderer.swift
@@ -17,6 +17,7 @@ public var defaultTags: [String: TagRenderer] {
     return [
         "": Print(),
         "contains": Contains(),
+        "containsKey": ContainsKey(),
         "lowercase": Lowercase(),
         "uppercase": Uppercase(),
         "capitalize": Capitalize(),


### PR DESCRIPTION
When building forms (this is an example of the use of this tag, there can be many other), I usually tend to build a dictionary of validation errors as `["name_of_the_field": "This is the validation error to show"]`.
With this tag, when looping over my fields, I could just test if the dictionary contains a validation error for a given field with `#if(containsKey(validationErrors, "name_of_the_field"))` and then display the error if needed.