### PR TITLE
Added support for passing userInfo to Encoder

### DIFF
--- a/Sources/TemplateKit/Data/TemplateDataEncoder.swift
+++ b/Sources/TemplateKit/Data/TemplateDataEncoder.swift
@@ -1,10 +1,14 @@
 /// Converts `Encodable` objects to `TemplateData`.
 public final class TemplateDataEncoder {
+    public let userInfo: [CodingUserInfoKey: Any]
+    
     /// Create a new `TemplateDataEncoder`.
-    public init() {}
+    public init(userInfo: [CodingUserInfoKey: Any] = [:]) {
+        self.userInfo = userInfo
+    }
 
     /// Encode an `Encodable` item to `TemplateData`.
-    public func encode<E>(_ encodable: E, on worker: Worker, userInfo: [CodingUserInfoKey: Any] = [:]) throws -> Future<TemplateData> where E: Encodable {
+    public func encode<E>(_ encodable: E, on worker: Worker) throws -> Future<TemplateData> where E: Encodable {
         if let representable = encodable as? TemplateDataRepresentable {
             // Shortcut if the argument is "trivially" representable as `TemplateData`.
             return worker.future(try representable.convertToTemplateData())
@@ -91,7 +95,7 @@ fileprivate final class _TemplateDataEncoder: Encoder, FutureEncoder, TemplateDa
         let userInfo = self.userInfo
         
         self.data = future.flatMap(to: TemplateData.self) { encodable in
-            try TemplateDataEncoder().encode(encodable, on: self.eventLoop, userInfo: userInfo)
+            try TemplateDataEncoder(userInfo: userInfo).encode(encodable, on: self.eventLoop)
         }
     }
 

--- a/Sources/TemplateKit/Pipeline/TemplateRenderer.swift
+++ b/Sources/TemplateKit/Pipeline/TemplateRenderer.swift
@@ -48,7 +48,7 @@ extension TemplateRenderer {
     /// See `ViewRenderer`.
     public func render<E>(_ path: String, _ context: E, userInfo: [AnyHashable: Any]) -> Future<View> where E: Encodable {
         do {
-            return try TemplateDataEncoder().encode(context, on: self.container).flatMap { context in
+            return try TemplateDataEncoder().encode(context, on: self.container, userInfo: _mapUserInfo(userInfo)).flatMap { context in
                 return self.render(path, context, userInfo: userInfo)
             }
         } catch {
@@ -100,7 +100,7 @@ extension TemplateRenderer {
     /// - returns: `Future` containing the rendered `View`.
     public func render<E>(template: Data, _ context: E, userInfo: [AnyHashable: Any] = [:]) -> Future<View> where E: Encodable {
         do {
-            return try TemplateDataEncoder().encode(context, on: self.container).flatMap { context in
+            return try TemplateDataEncoder().encode(context, on: self.container, userInfo: _mapUserInfo(userInfo)).flatMap { context in
                 return self.render(template: template, context, userInfo: userInfo)
             }
         } catch {
@@ -141,5 +141,13 @@ extension TemplateRenderer {
     private func _parse(_ template: Data, file: String) throws -> [TemplateSyntax] {
         let scanner = TemplateByteScanner(data: template, file: file)
         return try parser.parse(scanner: scanner)
+    }
+    
+    /// Filters `CodingUserInfoKey` keyed information to pass to `TemplateData`.encode()
+    private func _mapUserInfo(_ userInfo: [AnyHashable: Any]) -> [CodingUserInfoKey: Any] {
+        let filteredEntries = userInfo.filter { $0.key as? CodingUserInfoKey != nil }
+        let codingUserInfoKeyEntries = filteredEntries.map { ($0.key as! CodingUserInfoKey, $0.value) }
+            
+        return Dictionary(uniqueKeysWithValues: codingUserInfoKeyEntries)
     }
 }

--- a/Sources/TemplateKit/Pipeline/TemplateRenderer.swift
+++ b/Sources/TemplateKit/Pipeline/TemplateRenderer.swift
@@ -48,7 +48,7 @@ extension TemplateRenderer {
     /// See `ViewRenderer`.
     public func render<E>(_ path: String, _ context: E, userInfo: [AnyHashable: Any]) -> Future<View> where E: Encodable {
         do {
-            return try TemplateDataEncoder().encode(context, on: self.container, userInfo: _mapUserInfo(userInfo)).flatMap { context in
+            return try TemplateDataEncoder(userInfo: _mapUserInfo(userInfo)).encode(context, on: self.container).flatMap { context in
                 return self.render(path, context, userInfo: userInfo)
             }
         } catch {
@@ -100,7 +100,7 @@ extension TemplateRenderer {
     /// - returns: `Future` containing the rendered `View`.
     public func render<E>(template: Data, _ context: E, userInfo: [AnyHashable: Any] = [:]) -> Future<View> where E: Encodable {
         do {
-            return try TemplateDataEncoder().encode(context, on: self.container, userInfo: _mapUserInfo(userInfo)).flatMap { context in
+            return try TemplateDataEncoder(userInfo: _mapUserInfo(userInfo)).encode(context, on: self.container).flatMap { context in
                 return self.render(template: template, context, userInfo: userInfo)
             }
         } catch {

--- a/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
+++ b/Tests/TemplateKitTests/TemplateDataEncoderTests.swift
@@ -370,7 +370,7 @@ class TemplateDataEncoderTests: XCTestCase {
 
         let testModel = UserInfoTest()
         
-        _ = try TemplateDataEncoder().testEncode(testModel, userInfo: UserInfoTest.testUserInfo)
+        _ = try TemplateDataEncoder(userInfo: UserInfoTest.testUserInfo).testEncode(testModel)
         XCTAssertTrue(testModel.userInfoProvided)
     }
 }
@@ -459,7 +459,7 @@ extension TemplateDataEncoderTests {
 }
 
 extension TemplateDataEncoder {
-    func testEncode<E>(_ encodable: E, on eventLoop: EventLoop = EmbeddedEventLoop(), userInfo: [CodingUserInfoKey: Any] = [:]) throws -> TemplateData where E: Encodable {
-        return try encode(encodable, on: eventLoop, userInfo: userInfo).wait()
+    func testEncode<E>(_ encodable: E, on eventLoop: EventLoop = EmbeddedEventLoop()) throws -> TemplateData where E: Encodable {
+        return try encode(encodable, on: eventLoop).wait()
     }
 }


### PR DESCRIPTION
This change allows the userInfo passed to render to be passed down the TemplateDateEncoder chain. This provides for the ability for Request-level information to be passed all the way into the view model during the Encoder process.

The only minor quirk is that the type on userInfo passed to render is very broad [AnyHashable: Any] where the type on Encoder.userInfo is [CodingUserInfoKey: Any]. I opted to filter for the subset and document the filter. I'm happy to consider alternatives.

Any feedback on alternatives to making such information available are happily accepted.